### PR TITLE
updating for april 16

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,43 @@
 			<tbody>
 				<tr>
 					<td style="width: 12%"><strong>When</strong></td>
+					<td>Apr 16th 2025 (The 3rd Wednesday of every month) <br>  
+					    Presenter arrives at 6:30 to setup. Introductions and New Business starts at 6:45. Presentation starts at 7:00 PM </td>
+				</tr>
+				<tr>
+					<td><strong>Where</strong></td>
+					<td>Northwest Mutual Bldg. 4th floor 
+					<p>4345 Southpoint Drive South. Jacksonville, FL 32216 </p> </td>
+				</tr>
+				<tr>	
+					<td><strong>Topic</strong></td>
+					<td>Open PLC, overview, installation and use of the ladder logic programming</td>
+				</tr>
+				<tr>
+					<td><strong>Synopsis</strong></td>
+					<td>Rob and Keith will be covering the basics on OpenPLC an  editor and runtime server for ladder logic programming.</td>
+				</tr>
+				<tr>
+					<td><strong>Presented By</strong></td>
+					<td>Rob and Keith</td>
+				</tr>
+				<tr>
+					<td><strong>Food Sponsor</strong></td>
+					<td>Pizza and Drinks  </td>
+				</tr>
+			</tbody>
+		</table>
+                <br>
+		<br>
+
+		
+	<!-- the Last Meeting Table      -->
+	<h2><span class="e" id="Last_Meeting">Last Meeting</span></h2>
+		<hr> <!-- this is a horizontal line -->
+		<table class="table" style="color:black; width:100%; background-color:#e9e5e5;">
+			<tbody>
+				<tr>
+					<td style="width: 12%"><strong>When</strong></td>
 					<td>Mar 19th 2025 (The 3rd Wednesday of every month) <br>  
 					    Presenter arrives at 6:30 to setup. Introductions and New Business starts at 6:45. Presentation starts at 7:00 PM </td>
 				</tr>
@@ -133,44 +170,6 @@
 					<td><strong>Food Sponsor</strong></td>
 					<td>Pizza and Drinks  </td>
 				</tr>
-			</tbody>
-		</table>
-                <br>
-		<br>
-
-		
-	<!-- the Last Meeting Table      -->
-	<h2><span class="e" id="Last_Meeting">Last Meeting</span></h2>
-		<hr> <!-- this is a horizontal line -->
-		<table class="table" style="color:black; width:100%; background-color:#e9e5e5;">
-			<tbody>
-				<tr>
-					<td style="width: 12%"><strong>When</strong></td>
-					<td>Feb 19th 2025 (The 3rd Wednesday of every month) <br>  
-					    Presenter arrives at 6:30 to setup. Introductions and New Business starts at 6:45. Presentation starts at 7 PM </td>
-				</tr>
-				<tr>
-					<td><strong>Where</strong></td>
-					<td>Northwest Mutual Bldg. 4th floor
-					<p>4345 Southpoint Drive South. Jacksonville, FL 32216 </p></td>
-				</tr>
-				<tr>	
-					<td><strong>Topic</strong></td>
-					<td>Webtops, Let Em Rip! Linux Virtual Desktops in a Browser!</a>  </td>
-				</tr>
-				<tr>
-					<td><strong>Synopsis</strong></td>
-					<td>Kasm, xrdp, Guacamole, VNC, Docker, and more! This month, we’ll explore the exciting world of Linux webtop clients—covering how to install, configure, 
-						and use these powerful tools to access Linux desktops through your browser.</td>
-				</tr>
-				<tr>
-					<td><strong>Presented By</strong></td>
-					<td>Christian</td>
-				</tr>
-				<tr>
-					<td><strong>Food Sponsor</strong></td>
-					<td>Sandwishes and Drinks</td>
-				</tr>									
 			</tbody>
 		</table>
 		<br>


### PR DESCRIPTION
Updated for April 16th meeting, the history section did not need to be updated.

<img width="1134" alt="Screenshot 2025-04-06 at 3 39 39 PM" src="https://github.com/user-attachments/assets/c1f61150-35c9-40f2-b77c-c936f6bb4b22" />

<img width="1132" alt="Screenshot 2025-04-06 at 3 40 05 PM" src="https://github.com/user-attachments/assets/8e52dc1e-6cd1-468a-a9ce-98f1353bbfc0" />
